### PR TITLE
feat: post purge request

### DIFF
--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -9,10 +9,11 @@ type Context struct {
 }
 
 type PurgeRequest struct {
-	PurgeType   string   `json:"purgeType"`   // "urls" or "cache-tags"
-	ActionType  string   `json:"actionType"`  // "invalidate" or "delete"
-	Environment string   `json:"environment"` // "production" or "staging"
-	Paths       []string `json:"paths"`
+	PurgeType        string   `json:"purgeType"`                  // "urls" or "cache-tags"
+	ActionType       string   `json:"actionType"`                 // "invalidate" or "delete"
+	Environment      string   `json:"environment"`                // "production" or "staging"
+	PostPurgeRequest bool     `json:"postPurgeRequest,omitempty"` // true or false
+	Paths            []string `json:"paths"`
 }
 
 type AkamaiResponse struct {

--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -14,6 +14,10 @@ type ConfigSpec struct {
 		ClientToken  string `yaml:"client_token"`
 		AccessToken  string `yaml:"access_token"`
 	} `yaml:"akamai"`
+	PostPurgeRequest struct {
+		Enabled bool              `yaml:"enabled"`
+		Headers map[string]string `yaml:"headers"`
+	} `yaml:"post_purge_request"`
 	Logs struct {
 		ShowAccessLogs bool `yaml:"show_access_logs"`
 		JwtUser        struct {

--- a/config/samples/config.yaml
+++ b/config/samples/config.yaml
@@ -8,6 +8,12 @@ akamai:
   client_secret: "your-client-secret"
   client_token: "your-client-token"
   access_token: "your-access-token"
+
+post_purge_request:
+  enabled: true
+  headers:
+    X-Custom-Header: "value"
+
 logs:
   show_access_logs: true
   jwt_user:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -6,9 +6,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v9/pkg/edgegrid"
 	"github.com/gofiber/fiber/v2"
-	"net/http"
 )
 
 var (
@@ -113,6 +114,13 @@ func PurgeHandler(ctx v1alpha1.Context) func(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusInternalServerError).JSON(map[string]string{
 				"error": "Failed to decode Akamai response",
 			})
+		}
+
+		// Send a GET requests to purged URLs
+		if req.PostPurgeRequest && ctx.Config.PostPurgeRequest.Enabled {
+			for _, path := range req.Paths {
+				fmt.Printf("Sending GET request to %s\n", path)
+			}
 		}
 
 		// Forward the Akamai response to the client

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -6,7 +6,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"time"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v9/pkg/edgegrid"
 	"github.com/gofiber/fiber/v2"
@@ -117,14 +119,52 @@ func PurgeHandler(ctx v1alpha1.Context) func(c *fiber.Ctx) error {
 		}
 
 		// Send a GET requests to purged URLs
-		if req.PostPurgeRequest && ctx.Config.PostPurgeRequest.Enabled {
-			for _, path := range req.Paths {
-				fmt.Printf("Sending GET request to %s\n", path)
-			}
+		if is2xx(akamaiResp.HTTPStatus) && req.PostPurgeRequest && ctx.Config.PostPurgeRequest.Enabled {
+			time.Sleep(5 * time.Second) // Wait for 5 seconds before sending GET requests
+			executePurgeRequest(req.Paths, ctx)
 		}
 
 		// Forward the Akamai response to the client
 		ctx.Logger.Infof(`akamai-response,detail='%s',status=%d`, akamaiResp.Detail, akamaiResp.HTTPStatus)
 		return c.Status(resp.StatusCode).JSON(akamaiResp)
 	}
+}
+
+func executePurgeRequest(paths []string, ctx v1alpha1.Context) {
+	client := &http.Client{}
+
+	for _, path := range paths {
+		// Create the HTTP GET request
+		getRequest, err := http.NewRequest("GET", path, nil)
+		if err != nil {
+			ctx.Logger.Errorf("Failed to create GET request for %s: %v\n", path, err)
+			continue
+		}
+
+		// Add custom headers from configuration
+		for key, value := range ctx.Config.PostPurgeRequest.Headers {
+			getRequest.Header.Set(key, value)
+		}
+
+		// Send the GET request
+		response, err := client.Do(getRequest)
+		if err != nil {
+			ctx.Logger.Errorf("Failed to send GET request to %s: %v\n", path, err)
+			continue
+		}
+
+		// Read and discard the body to complete the request properly
+		_, err = io.ReadAll(response.Body)
+		if err != nil {
+			ctx.Logger.Warnf("Failed to read response body from %s: %v\n", path, err)
+		}
+		response.Body.Close()
+
+		// Log the response status
+		ctx.Logger.Infof("GET request to %s returned status code %d\n", path, response.StatusCode)
+	}
+}
+
+func is2xx(status int) bool {
+	return status >= 200 && status < 300
 }

--- a/public/static/script.js
+++ b/public/static/script.js
@@ -7,6 +7,7 @@ document.getElementById('purge-form').addEventListener('submit', async function(
     const purgeType = document.getElementById('purge-type').value;
     const actionType = document.getElementById('action-type').value;
     const environment = document.getElementById('environment').value;
+    const postPurgeRequest = document.getElementById('post-request').checked;
     const paths = document.getElementById('paths').value.trim().split('\n').filter(Boolean);
 
     if (paths.length === 0) {
@@ -25,6 +26,7 @@ document.getElementById('purge-form').addEventListener('submit', async function(
                 purgeType,
                 actionType,
                 environment,
+                postPurgeRequest,
                 paths
             })
         });

--- a/public/templates/index.html
+++ b/public/templates/index.html
@@ -35,6 +35,12 @@
             <option value="staging">Staging</option>
         </select>
 
+        <!-- Request Post Purge Checkbox -->
+        <div class="post-request-checkbox">
+            <input type="checkbox" id="post-request" name="post-request" required>
+            <label for="post-request">Execute request post purge (only with url purge type)</label>
+        </div>
+        
         <label for="paths">Enter paths/tags to purge (one per line):</label>
         <textarea id="paths" name="paths" placeholder="https://domain.com/example/path1
 https://domain.com/example/path2"></textarea>


### PR DESCRIPTION
**FEATURE**
This PR introduces a new feature to the Akamai cache purging service that allows executing an additional HTTP request after a successful purge operation.

**CHANGES**
- Added support for performing a post-purge request once the purge process is completed.
- Implemented a new helper function executePurgeRequest that sends configurable HTTP GET requests to specified paths.
- Included custom header support via ctx.Config.PostPurgeRequest.Headers.
- Ensured proper response handling:
  - The full response body is read (io.ReadAll) to allow efficient connection reuse.
  - The response body is explicitly closed at the end of each iteration to prevent resource leaks.
  - Status codes and errors are logged for observability and debugging.
 
- Upgrade the front with a checkbox.
<img width="1503" height="1008" alt="Screenshot from 2025-10-07 10-53-41" src="https://github.com/user-attachments/assets/a2fdd743-f394-4e58-8138-55438dfb2de8" />

**MOTIVATION**
This feature enables teams to automatically trigger post-purge actions, such as:
- Hitting specific endpoints to refresh content or warm caches.
- Notifying downstream services after cache invalidation.
- Executing monitoring or validation requests once a purge completes.