### PR TITLE
feat: add imbypass feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ go.work
 *~
 
 examples/**
+
+.claude/
+CLAUDE.md

--- a/api/v1alpha1/app_types.go
+++ b/api/v1alpha1/app_types.go
@@ -13,6 +13,7 @@ type PurgeRequest struct {
 	ActionType       string   `json:"actionType"`                 // "invalidate" or "delete"
 	Environment      string   `json:"environment"`                // "production" or "staging"
 	PostPurgeRequest bool     `json:"postPurgeRequest,omitempty"` // true or false
+	ImBypass         bool     `json:"imBypass,omitempty"`         // true or false
 	Paths            []string `json:"paths"`
 }
 

--- a/public/static/script.js
+++ b/public/static/script.js
@@ -8,6 +8,7 @@ document.getElementById('purge-form').addEventListener('submit', async function(
     const actionType = document.getElementById('action-type').value;
     const environment = document.getElementById('environment').value;
     const postPurgeRequest = document.getElementById('post-request').checked;
+    const imBypass = document.getElementById('im-bypass').checked;
     const paths = document.getElementById('paths').value.trim().split('\n').filter(Boolean);
 
     if (paths.length === 0) {
@@ -27,6 +28,7 @@ document.getElementById('purge-form').addEventListener('submit', async function(
                 actionType,
                 environment,
                 postPurgeRequest,
+                imBypass,
                 paths
             })
         });
@@ -48,6 +50,10 @@ document.getElementById('purge-form').addEventListener('submit', async function(
 document.addEventListener("DOMContentLoaded", () => {
     const purgeTypeSelect = document.getElementById("purge-type");
     const pathsTextarea = document.getElementById("paths");
+    const postRequestCheckbox = document.getElementById("post-request");
+    const postRequestContainer = postRequestCheckbox.parentElement;
+    const imBypassCheckbox = document.getElementById("im-bypass");
+    const imBypassContainer = imBypassCheckbox.parentElement;
 
     // Definir los placeholders para cada opción
     const placeholders = {
@@ -55,9 +61,26 @@ document.addEventListener("DOMContentLoaded", () => {
         "cache-tags": "tag1\ntag2\ntag3"
     };
 
+    // Function to update visibility of checkboxes (only visible for urls)
+    const updateCheckboxesVisibility = (purgeType) => {
+        if (purgeType === 'urls') {
+            postRequestContainer.style.display = 'block';
+            imBypassContainer.style.display = 'block';
+        } else {
+            postRequestContainer.style.display = 'none';
+            imBypassContainer.style.display = 'none';
+            postRequestCheckbox.checked = false;
+            imBypassCheckbox.checked = false;
+        }
+    };
+
     // Actualizar el placeholder cuando cambie el tipo de purga
     purgeTypeSelect.addEventListener("change", (event) => {
         const selectedType = event.target.value;
         pathsTextarea.placeholder = placeholders[selectedType] || "";
+        updateCheckboxesVisibility(selectedType);
     });
+
+    // Initialize visibility on page load
+    updateCheckboxesVisibility(purgeTypeSelect.value);
 });

--- a/public/templates/index.html
+++ b/public/templates/index.html
@@ -37,10 +37,16 @@
 
         <!-- Request Post Purge Checkbox -->
         <div class="post-request-checkbox">
-            <input type="checkbox" id="post-request" name="post-request" required>
+            <input type="checkbox" id="post-request" name="post-request">
             <label for="post-request">Execute request post purge (only with url purge type)</label>
         </div>
-        
+
+        <!-- IM Bypass Checkbox -->
+        <div class="post-request-checkbox">
+            <input type="checkbox" id="im-bypass" name="im-bypass">
+            <label for="im-bypass">Duplicate URLs with imbypass=true query parameter</label>
+        </div>
+
         <label for="paths">Enter paths/tags to purge (one per line):</label>
         <textarea id="paths" name="paths" placeholder="https://domain.com/example/path1
 https://domain.com/example/path2"></textarea>


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                
                                                                                                                                                                                                            
  Added a new feature to duplicate URLs with the `imbypass=true` query parameter during cache purge operations. This feature allows users to purge both the original URL and a version with the `imbypass`  
  parameter in a single operation.                                                                                                                                                                          
                                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                                
                                                                                                                                                                                                            
  ### Backend                                                                                                                                                                                               
                                                                                                                                                                                                            
  **`api/v1alpha1/app_types.go`**                                                                                                                                                                           
  - Added `ImBypass` field to `PurgeRequest` struct to receive the boolean flag from the frontend                                                                                                           
                                                                                                                                                                                                            
  **`internal/api/api.go`**                                                                                                                                                                                 
  - Added logic to duplicate URLs when `ImBypass` is enabled and `PurgeType` is "urls"                                                                                                                      
  - Implemented `duplicatePathsWithImBypass()` function to create duplicated URL arrays                                                                                                                     
  - Implemented `addQueryParam()` helper function to properly append query parameters to URLs (handles both `?` and `&` separators)                                                                         
                                                                                                                                                                                                            
  ### Frontend                                                                                                                                                                                              
                                                                                                                                                                                                            
  **`public/templates/index.html`**                                                                                                                                                                         
  - Added new checkbox "Duplicate URLs with imbypass=true query parameter"                                                                                                                                  
  - Positioned below the existing post-purge request checkbox                                                                                                                                               
                                                                                                                                                                                                            
  **`public/static/script.js`**                                                                                                                                                                             
  - Added `imBypass` field to the API request payload                                                                                                                                                       
  - Updated `updateCheckboxesVisibility()` function to control visibility of both checkboxes (post-request and im-bypass)                                                                                   
  - Both checkboxes now only display when purge type is "urls" (hidden for "cache-tags")                                                                                                                    
                                                                                                                                                                                                            
  ## How It Works                                                                                                                                                                                           
                                                                                                                                                                                                            
  1. User enables the "Duplicate URLs with imbypass=true query parameter" checkbox                                                                                                                          
  2. Frontend sends `imBypass: true` in the POST request body                                                                                                                                               
  3. Backend receives the request and duplicates each URL:                                                                                                                                                  
     - Original URL is preserved                                                                                                                                                                            
     - A duplicate with `imbypass=true` query parameter is added                                                                                                                                            
  4. Both versions are sent to Akamai for purging 